### PR TITLE
VS Code devcontainer is added to the nrp-core

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "image": "hbpneurorobotics/nrp-gazebo-nest-ubuntu20-env:latest",
+    // "image": "hbpneurorobotics/nrp-ubuntu20-env:latest",
+  
+    "customizations": {
+      "vscode": {
+        "extensions": ["mhutchie.git-graph"]
+      }
+    },
+    "containerEnv": {
+        "CMAKE_CACHE_FILE": ".ci/cmake_cache/nest-gazebo.cmake"
+    }
+    // "forwardPorts": [3000]
+  }

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 build
 .vscode
+.devcontainer
 .pytest_cache
 generatedJUnitFiles
 .git


### PR DESCRIPTION
The default devcontainer is base on `hbpneurorobotics/nrp-gazebo-nest-ubuntu20-env:latest` Docker image