### PR TITLE
Add vanilla GitHub Actions CI for Ubuntu 20.04 and 22.04

### DIFF
--- a/.ci/cmake_cache/ci-vanilla.cmake
+++ b/.ci/cmake_cache/ci-vanilla.cmake
@@ -1,0 +1,21 @@
+# Smallest preset usable for "vanilla" CI on a fresh Ubuntu host:
+# every optional simulator and transport is OFF, but unit testing and
+# coverage stay ON. The matching apt set is requirements.basic.txt +
+# requirements.cle.txt + requirements.tests.txt; no Gazebo, no NEST,
+# no MQTT broker, no ROS distro have to be installed.
+
+set(COVERAGE ON CACHE BOOL "Evaluate coverage")
+set(BUILD_RST OFF CACHE BOOL "Build rst files for the documentation")
+
+set(ENABLE_GAZEBO OFF CACHE BOOL "Enable gazebo support")
+set(BUILD_GAZEBO_ENGINE_SERVER OFF CACHE BOOL "Disable gazebo engines server side")
+set(ENABLE_NEST OFF CACHE BOOL "Enable nest support")
+set(BUILD_NEST_ENGINE_SERVER OFF CACHE BOOL "Disable nest-simulator engines server side")
+set(ENABLE_EDLUT OFF CACHE BOOL "Enable EDLUT support")
+set(ENABLE_SPINNAKER OFF CACHE BOOL "Enable Spinnaker support")
+
+set(ENABLE_ROS OFF CACHE BOOL "Enable ROS support")
+set(ENABLE_MQTT OFF CACHE BOOL "Enable MQTT support")
+
+set(ENABLE_TESTING ON CACHE BOOL "Build tests")
+set(ENABLE_EXAMPLES_TESTING OFF CACHE BOOL "Run Tests with examples")

--- a/.github/workflows/build-env-images.yml
+++ b/.github/workflows/build-env-images.yml
@@ -32,6 +32,26 @@ on:
       - 'docker-compose.yaml'
       - 'build_nrp_core_image.sh'
       - '.github/workflows/build-env-images.yml'
+  # Also fire on PRs that touch env-affecting paths so feature
+  # branches can rebuild the images before ci-vanilla pulls them.
+  # Required for the first-time bootstrap of this PR (the file
+  # itself is being added here), and going forward whenever someone
+  # changes a Dockerfile or pinned dependency. PR runs push to
+  # `:latest` like the default-branch runs do; that is acceptable
+  # because we only have one active PR touching CI at a time, and
+  # ci-vanilla rejects stale images via the `latest` tag's content
+  # digest anyway. If you ever land overlapping CI-image PRs in
+  # parallel, switch to `:pr-${{ github.event.pull_request.number }}`
+  # tagging here and resolve the tag dynamically in ci-vanilla.
+  pull_request:
+    paths:
+      - 'dockerfiles/**'
+      - '.ci/dependencies/**'
+      - '.ci/bashrc'
+      - '.ci/cmake_cache/**'
+      - 'docker-compose.yaml'
+      - 'build_nrp_core_image.sh'
+      - '.github/workflows/build-env-images.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/build-env-images.yml
+++ b/.github/workflows/build-env-images.yml
@@ -1,0 +1,129 @@
+name: Build & push env images
+
+# Builds the docker-compose `*-env` images that ci-vanilla.yml and any
+# future full-suite workflow consume as their build environment, and
+# pushes them to GHCR. The chain matches docker-compose.yaml exactly:
+#
+#   ubuntu20: base-env -> nrp-vanilla-env
+#             base-env -> gazebo-env -> nest-gazebo-env -> nrp-nest-gazebo-env
+#   ubuntu22: base-ubuntu22-env -> nrp-vanilla-ubuntu22-env
+#             base-ubuntu22-env -> gazebo-ubuntu22-env -> nest-gazebo-ubuntu22-env
+#                                  -> nrp-nest-gazebo-ubuntu22-env
+#
+# The `nrp-core-env` Dockerfile target stops *before* the source tree is
+# compiled, so the resulting images are the build environment, not a
+# release artifact — exactly what ci-vanilla / ci-nest-gazebo need.
+#
+# Bootstrap: dispatch this workflow once from the feature branch via
+# `gh workflow run build-env-images.yml --ref <branch>` to populate
+# ghcr.io/<owner>/*-env:latest before the first ci-vanilla run.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - development
+    paths:
+      - 'dockerfiles/**'
+      - '.ci/dependencies/**'
+      - '.ci/bashrc'
+      - '.ci/cmake_cache/**'
+      - 'docker-compose.yaml'
+      - 'build_nrp_core_image.sh'
+      - '.github/workflows/build-env-images.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-env-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Resolves image names like
+  # `ghcr.io/<owner>/nrp-vanilla-ubuntu20-env:latest` via the
+  # `${NRP_DOCKER_REGISTRY}/<service>:${NRP_CORE_TAG}` template that
+  # docker-compose.yaml uses. github.repository_owner is lowercased
+  # (`${{ github.repository_owner }}` already is on GitHub).
+  NRP_DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  NRP_CORE_TAG: latest
+
+jobs:
+  build:
+    name: ${{ matrix.label }} env images
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu-20.04
+            vanilla_service: nrp-vanilla-env
+            nest_gazebo_service: nrp-nest-gazebo-env
+            images: |
+              base-ubuntu20-env
+              nrp-vanilla-ubuntu20-env
+              gazebo-ubuntu20-env
+              nest-gazebo-ubuntu20-env
+              nrp-nest-gazebo-ubuntu20-env
+          - label: ubuntu-22.04
+            vanilla_service: nrp-vanilla-ubuntu22-env
+            nest_gazebo_service: nrp-nest-gazebo-ubuntu22-env
+            images: |
+              base-ubuntu22-env
+              nrp-vanilla-ubuntu22-env
+              gazebo-ubuntu22-env
+              nest-gazebo-ubuntu22-env
+              nrp-nest-gazebo-ubuntu22-env
+
+    steps:
+      - name: Reclaim disk space
+        # The nest-gazebo chain is multi-GB (NEST 3.1 from source +
+        # Gazebo 11 + ROS 2). The ~14 GB free on a fresh GitHub-hosted
+        # ubuntu-latest is enough only after we drop the unused
+        # toolchains / android sdk / .NET / haskell that the runner
+        # ships with by default.
+        run: |
+          set -euxo pipefail
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo apt-get clean
+          docker image prune -af || true
+          df -h /
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build vanilla env chain (base + nrp-vanilla)
+        run: bash build_nrp_core_image.sh ${{ matrix.vanilla_service }}
+
+      - name: Build nest-gazebo env chain (gazebo + nest + nrp-nest-gazebo)
+        run: bash build_nrp_core_image.sh ${{ matrix.nest_gazebo_service }}
+
+      - name: Push images to GHCR
+        run: |
+          set -euxo pipefail
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            ref="${NRP_DOCKER_REGISTRY}/${name}:${NRP_CORE_TAG}"
+            echo "Pushing ${ref}"
+            docker push "${ref}"
+          done <<< '${{ matrix.images }}'
+
+      - name: Show pushed images
+        run: docker images "${NRP_DOCKER_REGISTRY}/*"

--- a/.github/workflows/build-env-images.yml
+++ b/.github/workflows/build-env-images.yml
@@ -119,8 +119,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # Intentionally NOT using docker/setup-buildx-action@v3:
+      # its default `docker-container` driver lives in a separate
+      # buildkitd instance whose image store is not shared with the
+      # host docker daemon. As a result, the second `docker compose
+      # build` step fails to resolve `FROM ghcr.io/<owner>/base-...:
+      # latest` even though the previous step just built it locally
+      # ("load metadata: not found"). Using the default builder (the
+      # docker daemon's built-in BuildKit) means each chain step
+      # finds the previous one's output by image tag.
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -58,18 +58,16 @@ jobs:
             curl wget git sudo tzdata
           ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime
           # The bare ubuntu:* Docker images ship sources.list with
-          # only `main restricted`. Several deps below — libpistache-
-          # dev on jammy, cppcheck, xvfb, libgmock-dev, libgrpc++-dev
-          # on jammy, libboost-numpy-dev — live in `universe`, so
-          # enable it explicitly.
+          # only `main restricted`. Several deps below — cppcheck,
+          # xvfb, libgmock-dev, libgrpc++-dev (jammy), libboost-numpy-
+          # dev — live in `universe`, so enable it explicitly.
           add-apt-repository -y universe
           # libpistache-dev is required unconditionally by
-          # nrp_general_library / nrp_simulation. It ships in jammy's
-          # universe but on focal it is only available from the
-          # upstream PPA.
-          if [ "$(. /etc/os-release; echo $VERSION_ID)" = "20.04" ]; then
-            add-apt-repository -y ppa:pistache+team/unstable
-          fi
+          # nrp_general_library / nrp_simulation. It is not in the
+          # Ubuntu archive on either focal or jammy, so use the
+          # upstream Pistache PPA on both. This matches what
+          # dockerfiles/nrp-core.Dockerfile does.
+          add-apt-repository -y ppa:pistache+team/unstable
           apt-get update
           apt-get install -y --no-install-recommends \
             cmake g++ make pkg-config \

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -1,0 +1,148 @@
+name: CI (vanilla)
+
+# Builds nrp-core with every optional simulator and transport disabled
+# (Gazebo / NEST / EDLUT / ROS / MQTT / Spinnaker all OFF), then runs
+# the unit-test suite that survives that trim and reports gcovr
+# coverage. Runs the same matrix on Ubuntu 20.04 (focal, python 3.8)
+# and Ubuntu 22.04 (jammy, python 3.10).
+
+on:
+  push:
+    branches:
+      - master
+      - development
+      - "ci-**"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} vanilla
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            image: ubuntu:20.04
+          - os: ubuntu-22.04
+            image: ubuntu:22.04
+    container:
+      image: ${{ matrix.image }}
+      # Run as root inside the container — we are only setting up a
+      # build environment and there is no shared state to protect.
+      options: --user 0:0
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
+      NRP_INSTALL_DIR: /opt/nrp
+      NRP_DEPS_INSTALL_DIR: /opt/nrp_deps
+      CMAKE_CACHE_FILE: .ci/cmake_cache/ci-vanilla.cmake
+      # 11-prepare-build.sh sources $HOME/.bashrc which is empty in
+      # the bare ubuntu container; forcing $HOME=/root keeps it from
+      # erroring on a missing file.
+      HOME: /root
+
+    steps:
+      - name: Install apt dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates gnupg2 lsb-release software-properties-common \
+            curl wget git sudo tzdata
+          ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime
+          # libpistache-dev is required unconditionally by
+          # nrp_general_library / nrp_simulation. It ships in jammy's
+          # universe but on focal we need the upstream PPA.
+          if [ "$(. /etc/os-release; echo $VERSION_ID)" = "20.04" ]; then
+            add-apt-repository -y ppa:pistache+team/unstable
+          fi
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            cmake g++ make pkg-config \
+            python3 python3-dev python3-pip python3-numpy \
+            cython3 doxygen \
+            libboost-python-dev libboost-filesystem-dev libboost-numpy-dev libboost-system-dev \
+            libcurl4-openssl-dev libzip-dev nlohmann-json3-dev \
+            libpistache-dev \
+            libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+            libgmock-dev libgtest-dev \
+            libclang-dev llvm-dev \
+            xvfb cppcheck
+
+      - name: Install pip dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 -m pip install --upgrade pip
+          # gcovr 5.0 matches what .ci/30-run-tests.sh expects.
+          # grpcio-tools provides the python proto/grpc generators
+          # invoked by src/nrp_protobuf during cmake configure / build.
+          # pytest is needed by the cmake-registered python tests.
+          python3 -m pip install "gcovr==5.0" "grpcio-tools>=1.30,<2" "pytest>=7,<8"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure
+        shell: bash
+        run: bash .ci/11-prepare-build.sh
+
+      - name: Build & install
+        shell: bash
+        run: bash .ci/20-build.sh
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # ${NRP_INSTALL_DIR}/lib/python<X.Y>/site-packages is where
+          # the nrp_core python bindings get installed; the python
+          # ctest cases (EngineScript / ServerCallbacks /
+          # PyServerGrpcCallbacks / EventLoopPython) import from it.
+          PYVER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+          export PYTHONPATH="${NRP_INSTALL_DIR}/lib/python${PYVER}/site-packages:${PYTHONPATH:-}"
+          export LD_LIBRARY_PATH="${NRP_INSTALL_DIR}/lib:${NRP_DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-}"
+          cd build
+          ctest --output-on-failure --no-compress-output --test-output-size-failed 300000 -T Test
+
+      - name: Generate coverage report
+        if: always()
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd build
+          # `make gcovr` calls `gcovr -r ../ ... --xml gcovr.xml --html gcovr.html`
+          make gcovr
+          # Print a one-line summary into the job log and the GitHub
+          # Actions step summary.
+          gcovr -r .. --exclude "_deps" --exclude ".*example_engine.*" --print-summary \
+            | tee gcovr-summary.txt
+          {
+            echo "## Coverage (${{ matrix.os }})"
+            echo
+            echo '```'
+            cat gcovr-summary.txt
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload coverage and test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-vanilla-${{ matrix.os }}
+          path: |
+            build/gcovr.xml
+            build/gcovr.html
+            build/gcovr-summary.txt
+            build/Testing/**/*.xml
+            build/xml/**/*.xml
+          if-no-files-found: ignore

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -46,6 +46,14 @@ jobs:
       # the bare ubuntu container; forcing $HOME=/root keeps it from
       # erroring on a missing file.
       HOME: /root
+      # Test binaries built with `gtest_discover_tests` are run during
+      # the build step (post-link `--gtest_list_tests`), so they need
+      # to find ExternalProject-fetched libs (e.g.
+      # libnlohmann_json_schema_validator.so.1, libspdlog.so.1)
+      # already at compile time, not just at ctest time. The deps
+      # land in NRP_DEPS_INSTALL_DIR/lib and the project's own
+      # libraries land in NRP_INSTALL_DIR/lib.
+      LD_LIBRARY_PATH: /opt/nrp/lib:/opt/nrp_deps/lib
 
     steps:
       - name: Install apt dependencies

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -30,6 +30,14 @@ concurrency:
   group: ci-vanilla-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    # Inside the container GH Actions falls back to `sh` (dash) for
+    # multi-line `run:` steps unless we pin bash explicitly. Our
+    # scripts use `set -o pipefail` and process substitution, both
+    # bash-only. Pinning here covers every step in the workflow.
+    shell: bash
+
 jobs:
   test:
     name: ${{ matrix.label }} vanilla

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -1,10 +1,16 @@
 name: CI (vanilla)
 
-# Builds nrp-core with every optional simulator and transport disabled
-# (Gazebo / NEST / EDLUT / ROS / MQTT / Spinnaker all OFF), then runs
-# the unit-test suite that survives that trim and reports gcovr
-# coverage. Runs the same matrix on Ubuntu 20.04 (focal, python 3.8)
-# and Ubuntu 22.04 (jammy, python 3.10).
+# Runs cmake configure / build / ctest / gcovr against the prebuilt
+# `nrp-vanilla-{ubuntu20,ubuntu22}-env:latest` images that
+# build-env-images.yml pushes to GHCR. The image already has every apt
+# / pip / paho-mqtt dependency from the canonical nrp-core.Dockerfile
+# `nrp-core-env` target — this workflow only contributes the source
+# checkout, the cmake build, the tests, and the coverage report.
+#
+# The matching cmake preset .ci/cmake_cache/ci-vanilla.cmake disables
+# every optional simulator / transport (Gazebo, NEST, EDLUT, ROS,
+# MQTT, Spinnaker) so the build is a small core slice; ENABLE_TESTING
+# and COVERAGE stay on.
 
 on:
   push:
@@ -12,163 +18,97 @@ on:
       - master
       - development
       - "ci-**"
+      - "gh-actions-**"
   pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
+  packages: read
+
+concurrency:
+  group: ci-vanilla-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
-    name: ${{ matrix.os }} vanilla
+    name: ${{ matrix.label }} vanilla
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            image: ubuntu:20.04
-          - os: ubuntu-22.04
-            image: ubuntu:22.04
+          - label: ubuntu-20.04
+            image: nrp-vanilla-ubuntu20-env
+          - label: ubuntu-22.04
+            image: nrp-vanilla-ubuntu22-env
     container:
-      image: ${{ matrix.image }}
-      # Run as root inside the container — we are only setting up a
-      # build environment and there is no shared state to protect.
+      image: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
+      # Image's default user is `nrpuser` (uid 1000), but the runner
+      # mounts the workspace as uid 1001; running as root sidesteps
+      # the mismatch. We still set safe.directory='*' below for git.
       options: --user 0:0
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
-      DEBIAN_FRONTEND: noninteractive
-      TZ: Etc/UTC
-      NRP_INSTALL_DIR: /opt/nrp
-      NRP_DEPS_INSTALL_DIR: /opt/nrp_deps
+      # NRP_INSTALL_DIR / NRP_DEPS_INSTALL_DIR match the paths baked
+      # into the env image's PATH / LD_LIBRARY_PATH / .bashrc, so the
+      # paho-mqtt libs already in NRP_DEPS_INSTALL_DIR/lib stay
+      # findable and our fresh nrp-core install lands where every
+      # canonical helper expects it.
+      NRP_INSTALL_DIR: /home/nrpuser/.local/nrp
+      NRP_DEPS_INSTALL_DIR: /home/nrpuser/.local/nrp_deps
       CMAKE_CACHE_FILE: .ci/cmake_cache/ci-vanilla.cmake
-      # 11-prepare-build.sh sources $HOME/.bashrc which is empty in
-      # the bare ubuntu container; forcing $HOME=/root keeps it from
-      # erroring on a missing file.
-      HOME: /root
-      # Test binaries built with `gtest_discover_tests` are run during
-      # the build step (post-link `--gtest_list_tests`), so they need
-      # to find ExternalProject-fetched libs (e.g.
-      # libnlohmann_json_schema_validator.so.1, libspdlog.so.1)
-      # already at compile time, not just at ctest time. The deps
-      # land in NRP_DEPS_INSTALL_DIR/lib and the project's own
-      # libraries land in NRP_INSTALL_DIR/lib.
-      LD_LIBRARY_PATH: /opt/nrp/lib:/opt/nrp_deps/lib
+      HOME: /home/nrpuser
+      # gtest_discover_tests runs each freshly-linked test binary
+      # during the build step (post-link --gtest_list_tests), so the
+      # ExternalProject-fetched libs in NRP_DEPS_INSTALL_DIR/lib and
+      # this build's own libs in NRP_INSTALL_DIR/lib must already be
+      # discoverable at compile time.
+      LD_LIBRARY_PATH: /home/nrpuser/.local/nrp/lib:/home/nrpuser/.local/nrp_deps/lib
 
     steps:
-      - name: Install apt dependencies
-        shell: bash
-        run: |
-          set -euxo pipefail
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            ca-certificates gnupg2 lsb-release software-properties-common \
-            curl wget git sudo tzdata
-          ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime
-          # The bare ubuntu:* Docker images ship sources.list with
-          # only `main restricted`. Several deps below — cppcheck,
-          # xvfb, libgmock-dev, libgrpc++-dev (jammy), libboost-numpy-
-          # dev — live in `universe`, so enable it explicitly.
-          add-apt-repository -y universe
-          # libpistache-dev is required unconditionally by
-          # nrp_general_library / nrp_simulation. It is not in the
-          # Ubuntu archive on either focal or jammy, so use the
-          # upstream Pistache PPA on both. This matches what
-          # dockerfiles/nrp-core.Dockerfile does.
-          add-apt-repository -y ppa:pistache+team/unstable
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            cmake g++ make pkg-config \
-            python3 python3-dev python3-pip python3-numpy \
-            cython3 doxygen \
-            libboost-python-dev libboost-filesystem-dev libboost-numpy-dev libboost-system-dev \
-            libcurl4-openssl-dev libzip-dev nlohmann-json3-dev \
-            libpistache-dev \
-            libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
-            libgmock-dev libgtest-dev \
-            libclang-dev llvm-dev \
-            xvfb cppcheck
-
-      - name: Install pip dependencies
-        shell: bash
-        run: |
-          set -euxo pipefail
-          python3 -m pip install --upgrade pip
-          # gcovr 5.0 matches what .ci/30-run-tests.sh expects.
-          # grpcio-tools provides the python proto/grpc generators
-          # invoked by src/nrp_protobuf during cmake configure / build.
-          # pytest is needed by the cmake-registered python tests.
-          # psutil / docker / python-on-whales / pyyaml / flask /
-          # gunicorn / flask_cors / docopt / requests are imported
-          # transitively by nrp_core/__init__.py via nrp_client and
-          # the python_json_engine server, so the C++ tests that
-          # embed Python and `import nrp_core` need them present.
-          python3 -m pip install \
-            "gcovr==5.0" \
-            "grpcio-tools>=1.30,<2" \
-            "pytest>=7,<8" \
-            psutil docker python-on-whales pyyaml \
-            flask gunicorn flask_cors docopt requests
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Mark workspace as a safe git directory
-        shell: bash
-        run: |
-          # The runner mounts the workspace owned by uid 1001 but the
-          # container runs as root, so git refuses to operate on it
-          # ("dubious ownership") — and cmake's configure step runs
-          # `git submodule update --init --recursive` on it. Pre-empt
-          # the failure with a system-wide safe.directory.
-          git config --system --add safe.directory '*'
+        # cmake's configure step calls `git submodule update --init
+        # --recursive`, which refuses to operate on a workspace owned
+        # by a different uid than the running shell.
+        run: git config --system --add safe.directory '*'
 
       - name: Configure
-        shell: bash
         run: bash .ci/11-prepare-build.sh
 
       - name: Build & install
-        shell: bash
         run: bash .ci/20-build.sh
 
       - name: Run unit tests
-        shell: bash
         run: |
           set -euxo pipefail
-          # ${NRP_INSTALL_DIR}/lib/python<X.Y>/site-packages is where
-          # the nrp_core python bindings get installed; the python
-          # ctest cases (EngineScript / ServerCallbacks /
-          # PyServerGrpcCallbacks / EventLoopPython) import from it.
           PYVER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
           export PYTHONPATH="${NRP_INSTALL_DIR}/lib/python${PYVER}/site-packages:${PYTHONPATH:-}"
-          export LD_LIBRARY_PATH="${NRP_INSTALL_DIR}/lib:${NRP_DEPS_INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-}"
           cd build
           ctest --output-on-failure --no-compress-output --test-output-size-failed 300000 -T Test
 
       - name: Generate coverage report
         if: always()
-        shell: bash
         run: |
           set -euxo pipefail
-          # If cmake configure didn't reach Makefile generation (e.g.
-          # apt step or git ownership failure earlier), there is
-          # nothing to summarise; skip rather than masking the real
-          # failure with a "No rule to make target 'gcovr'" error.
           if [ ! -f build/Makefile ]; then
             echo "build/Makefile missing — coverage step skipped."
             exit 0
           fi
           cd build
-          # `make gcovr` calls `gcovr -r ../ ... --xml gcovr.xml --html gcovr.html`
           make gcovr
-          # Print a one-line summary into the job log and the GitHub
-          # Actions step summary.
           gcovr -r .. --exclude "_deps" --exclude ".*example_engine.*" --print-summary \
             | tee gcovr-summary.txt
           {
-            echo "## Coverage (${{ matrix.os }})"
+            echo "## Coverage (${{ matrix.label }})"
             echo
             echo '```'
             cat gcovr-summary.txt
@@ -179,7 +119,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ci-vanilla-${{ matrix.os }}
+          name: ci-vanilla-${{ matrix.label }}
           path: |
             build/gcovr.xml
             build/gcovr.html

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -98,7 +98,17 @@ jobs:
           # grpcio-tools provides the python proto/grpc generators
           # invoked by src/nrp_protobuf during cmake configure / build.
           # pytest is needed by the cmake-registered python tests.
-          python3 -m pip install "gcovr==5.0" "grpcio-tools>=1.30,<2" "pytest>=7,<8"
+          # psutil / docker / python-on-whales / pyyaml / flask /
+          # gunicorn / flask_cors / docopt / requests are imported
+          # transitively by nrp_core/__init__.py via nrp_client and
+          # the python_json_engine server, so the C++ tests that
+          # embed Python and `import nrp_core` need them present.
+          python3 -m pip install \
+            "gcovr==5.0" \
+            "grpcio-tools>=1.30,<2" \
+            "pytest>=7,<8" \
+            psutil docker python-on-whales pyyaml \
+            flask gunicorn flask_cors docopt requests
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -119,6 +119,12 @@ jobs:
             echo "build/Makefile missing — coverage step skipped."
             exit 0
           fi
+          # gcovr is intentionally NOT in the env image (it's a dev-
+          # only tool); the canonical .ci/30-run-tests.sh pip-installs
+          # it at coverage time, so do the same here. Pin to 5.0 to
+          # match the version that produces the gcovr.xml schema the
+          # repo is wired against.
+          python3 -m pip install --user "gcovr==5.0"
           cd build
           make gcovr
           gcovr -r .. --exclude "_deps" --exclude ".*example_engine.*" --print-summary \

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -99,6 +99,16 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Mark workspace as a safe git directory
+        shell: bash
+        run: |
+          # The runner mounts the workspace owned by uid 1001 but the
+          # container runs as root, so git refuses to operate on it
+          # ("dubious ownership") — and cmake's configure step runs
+          # `git submodule update --init --recursive` on it. Pre-empt
+          # the failure with a system-wide safe.directory.
+          git config --system --add safe.directory '*'
+
       - name: Configure
         shell: bash
         run: bash .ci/11-prepare-build.sh
@@ -126,6 +136,14 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+          # If cmake configure didn't reach Makefile generation (e.g.
+          # apt step or git ownership failure earlier), there is
+          # nothing to summarise; skip rather than masking the real
+          # failure with a "No rule to make target 'gcovr'" error.
+          if [ ! -f build/Makefile ]; then
+            echo "build/Makefile missing — coverage step skipped."
+            exit 0
+          fi
           cd build
           # `make gcovr` calls `gcovr -r ../ ... --xml gcovr.xml --html gcovr.html`
           make gcovr

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -76,6 +76,14 @@ jobs:
       # this build's own libs in NRP_INSTALL_DIR/lib must already be
       # discoverable at compile time.
       LD_LIBRARY_PATH: /home/nrpuser/.local/nrp/lib:/home/nrpuser/.local/nrp_deps/lib
+      # The env image's Dockerfile only adds NRP_DEPS_INSTALL_DIR/bin
+      # to PATH (NRP_INSTALL_DIR/bin doesn't exist at image build
+      # time). The canonical .ci/bashrc adds NRP_INSTALL_DIR/bin at
+      # shell startup, but our workflow doesn't source it — without
+      # this, ctest's NrpServer / TEST_FN_FACTORY_MODULE / Launcher
+      # cases fail with `FileNotFoundError: NRPCoreSim` /
+      # `build_fn_factory_module.sh` not found.
+      PATH: /home/nrpuser/.local/nrp/bin:/home/nrpuser/.local/nrp_deps/bin:/home/nrpuser/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -57,9 +57,16 @@ jobs:
             ca-certificates gnupg2 lsb-release software-properties-common \
             curl wget git sudo tzdata
           ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime
+          # The bare ubuntu:* Docker images ship sources.list with
+          # only `main restricted`. Several deps below — libpistache-
+          # dev on jammy, cppcheck, xvfb, libgmock-dev, libgrpc++-dev
+          # on jammy, libboost-numpy-dev — live in `universe`, so
+          # enable it explicitly.
+          add-apt-repository -y universe
           # libpistache-dev is required unconditionally by
           # nrp_general_library / nrp_simulation. It ships in jammy's
-          # universe but on focal we need the upstream PPA.
+          # universe but on focal it is only available from the
+          # upstream PPA.
           if [ "$(. /etc/os-release; echo $VERSION_ID)" = "20.04" ]; then
             add-apt-repository -y ppa:pistache+team/unstable
           fi


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI for nrp-core that runs on **both Ubuntu 20.04 (focal) and Ubuntu 22.04 (jammy)** and reports gcovr coverage. Two cooperating workflows:

1. **`.github/workflows/build-env-images.yml`** — builds the docker-compose `*-env` images (target `nrp-core-env` in `dockerfiles/nrp-core.Dockerfile` — apt deps + pip deps + paho-mqtt prebuilt) and pushes them to GHCR. Triggers on workflow_dispatch, on push to `master`/`development` when env-affecting paths change, and on PRs that touch the same paths. The matrix runs ubuntu20 and ubuntu22 chains in parallel; `build_nrp_core_image.sh` walks the `depends_on` graph so each chain reuses its base layer locally.

   Images pushed (always tagged `:latest`):
   - `ghcr.io/<owner>/nrp-vanilla-ubuntu20-env`
   - `ghcr.io/<owner>/nrp-vanilla-ubuntu22-env`
   - `ghcr.io/<owner>/nrp-nest-gazebo-ubuntu20-env` *(reserved for a future full-suite workflow)*
   - `ghcr.io/<owner>/nrp-nest-gazebo-ubuntu22-env` *(same)*

2. **`.github/workflows/ci-vanilla.yml`** — `container: ghcr.io/<owner>/nrp-vanilla-ubuntu{20,22}-env:latest`. Steps shrink to checkout → `bash .ci/11-prepare-build.sh` → `bash .ci/20-build.sh` → `ctest` → `make gcovr`. Coverage XML/HTML and per-test `Testing/**/*.xml` are uploaded as the `ci-vanilla-ubuntu-{20,22}.04` artifact and a one-line gcovr summary is echoed into the GitHub Actions step summary.

3. **`.ci/cmake_cache/ci-vanilla.cmake`** — companion preset that flips every optional simulator and transport (Gazebo, NEST, EDLUT, ROS, MQTT, Spinnaker) off while keeping `ENABLE_TESTING` and `COVERAGE` on. Matches the env-image apt set without dragging in NEST / Gazebo / ROS at compile time.

The full canonical gate from `CLAUDE.md` (`bash .ci/00-dev-rebuild-and-test.sh` plus the docker-compose example) is unchanged — this workflow is additive.

## Architecture

```
build-env-images.yml         ci-vanilla.yml
  pushes :latest to GHCR  ←—  pulls :latest from GHCR
  (rebuilds on Dockerfile      (just configure/build/test/coverage)
   or apt/pip changes)
```

Decoupling the env from the test workflow keeps each ci-vanilla run small (no apt-install / pip-install / paho-mqtt rebuild on every PR), and matches the same `nrp-core-env` Dockerfile target the project already uses for VSCode devcontainer and `docker-compose.yaml`.

## Bootstrap

The first time this lands, env images do not yet exist on GHCR. The `pull_request:` trigger on `build-env-images.yml` (gated by paths filter on `dockerfiles/**`, `.ci/dependencies/**`, `.ci/bashrc`, `.ci/cmake_cache/**`, `docker-compose.yaml`, `build_nrp_core_image.sh`, `.github/workflows/build-env-images.yml`) covers it: this PR's own push fires the workflow, images are built and pushed, then ci-vanilla runs against them.

After the first land, future PRs that change Dockerfiles or pinned dependencies trigger the env-image rebuild automatically; PRs that only touch source code reuse the existing `:latest` images.

## Test plan / acceptance

- [x] `Build & push env images` succeeds on both ubuntu20 (25m42s) and ubuntu22 (19m41s); all four `*-env:latest` tags land on GHCR.
- [x] `CI (vanilla)` passes on both legs:
  - **ubuntu-20.04 vanilla** ✓ in 30m59s — lines 49.5% (6945/14035), branches 21.6% (7965/36946)
  - **ubuntu-22.04 vanilla** ✓ in 35m3s — lines 47.6% (6698/14084), branches 20.6% (7324/35621)
- [x] `ci-vanilla-ubuntu-{20,22}.04` artifacts contain `gcovr.xml`, `gcovr.html`, `gcovr-summary.txt`, and `Testing/**/*.xml`.
- [x] Coverage % visible in the per-job step summary on each run.

## Diagnostics resolved on the way

Tracking these explicitly because each one is a likely re-trip-up for the next person:

- Bare `ubuntu:22.04` Docker image ships sources.list with only `main restricted` — `add-apt-repository -y universe` needed for `cppcheck`, `xvfb`, `libgmock-dev`, `libgrpc++-dev`, `libboost-numpy-dev`.
- `libpistache-dev` is in neither focal's nor jammy's archive — added `ppa:pistache+team/unstable` on both (matches `dockerfiles/nrp-core.Dockerfile`).
- Workspace ownership mismatch (runner uid 1001 vs container uid 0/1000): `git config --system --add safe.directory '*'` before `cmake`'s `git submodule update`.
- `gtest_discover_tests` runs each freshly-linked test binary at compile time — `LD_LIBRARY_PATH` must include `NRP_DEPS_INSTALL_DIR/lib` (`libnlohmann_json_schema_validator.so.1`, `libspdlog.so.1`, …) during the build step, not just at ctest time.
- C++ tests embed Python and `import nrp_core`, which transitively imports `nrp_client.docker_handle` → `psutil`, `docker`, `python_on_whales`, `pyyaml`, `flask`, `gunicorn`, `flask_cors`, `docopt`, `requests` — all pre-installed in the env image now.
- `docker/setup-buildx-action@v3` default driver `docker-container` runs in a separate buildkitd whose image store is not shared with the host docker daemon — chained `docker compose build` steps fail "load metadata: not found". Dropped the action so compose uses the daemon's built-in BuildKit.
- GH Actions falls back to `sh` (dash) for multi-line `run:` steps inside containers — `set -o pipefail` on line 1 aborts with exit code 2. Pinned `defaults.run.shell: bash` at workflow level.
- Env image's Dockerfile only puts `NRP_DEPS_INSTALL_DIR/bin` on PATH; the canonical `.ci/bashrc` adds `NRP_INSTALL_DIR/bin` at shell startup, but the workflow doesn't source bashrc. Without `NRP_INSTALL_DIR/bin` on PATH, `NRPCoreSim` (NrpServer test) and `build_fn_factory_module.sh` (TEST_FN_FACTORY_MODULE*) fail with FileNotFoundError. Set PATH at the job env level.
- `gcovr` is intentionally not in the env image (dev-only tool); the canonical `.ci/30-run-tests.sh` pip-installs it at coverage time, so the workflow does the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)