### PR TITLE
[EBR2-98] Fix NEST engine SIGSEGV on shutdown (deterministic singleton teardown)

### DIFF
--- a/src/nrp_nest_engines/nrp_nest_json_engine/nest_server_executable/main.cpp
+++ b/src/nrp_nest_engines/nrp_nest_json_engine/nest_server_executable/main.cpp
@@ -38,5 +38,16 @@ int main(int argc, char *argv[])
     server.waitForInit();
 
     // Run server
-    return server.run();
+    const int returnCode = server.run();
+
+    // Tear the singleton down here, while spdlog is still alive, rather than at
+    // static-destruction time. The server is held in a static unique_ptr; if it
+    // were destroyed during static teardown, a static NRPLogger's destructor may
+    // already have called the global spdlog::shutdown(), and the engine-server
+    // destructors' trace logging would then dereference freed spdlog state
+    // (SIGSEGV on shutdown). Destroying it explicitly here makes the order
+    // deterministic. [EBR2-98]
+    NestServerExecutable::shutdown();
+
+    return returnCode;
 }


### PR DESCRIPTION
## Problem
The NEST engine process (`NRPNestJSONExecutable`) segfaults on **every** simulation shutdown — `~EngineJSONServer`'s trace logging dereferences freed spdlog state.

## Root cause
`NestServerExecutable` is held in a **static `std::unique_ptr`**, so it's destroyed at process-exit static-destruction time, by which point a static `NRPLogger`'s destructor has already called the global `spdlog::shutdown()`.

## Fix
Destroy the singleton explicitly at the end of `main()` (via the existing `shutdown()`), while spdlog is still alive — deterministic order. One file.

## Validation
Diagnosis verified end-to-end against the published image. Local nest-gazebo gate (ctest + compose examples) + this PR's Actions build validate the compile/run.

Issue: https://hbpneurorobotics.atlassian.net/browse/EBR2-98