### PR TITLE
[EBR2-29] Pin paho-mqtt 2.x and migrate event_loop_engine to its callback API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo apt remove python3-flask python3-flask-cors
 # By installing flask version 1.1.4 markupsafe library (included with flask) has to be downgraded to version 2.0.1 to run properly with gunicorn
 # You can install that version with 
 # pip install flask==1.1.4 gunicorn markupsafe==2.0.1
-pip install flask gunicorn paho-mqtt==1.6.1
+pip install flask gunicorn "paho-mqtt>=2.0,<3"
 
 # required by nest-server (which is built and installed along with nrp-core)
 sudo apt install python3-restrictedpython uwsgi-core uwsgi-plugin-python3 

--- a/dockerfiles/nrp-core.Dockerfile
+++ b/dockerfiles/nrp-core.Dockerfile
@@ -29,7 +29,7 @@ RUN sudo apt-get update && sudo apt-get -y install $(grep -vE "^\s*#" ${HOME}/.d
 # pytest 7.x satisfies both. /home/nrpuser/.local/lib/python3.8/site-
 # packages is already ahead of /usr/lib/python3/dist-packages on
 # sys.path, so the pip-user pytest wins over the apt-provided 4.6.9.
-RUN pip install "grpcio-tools>=1.62.2" "pytest>=7,<8" psutil flask gunicorn flask_cors mpi4py docopt docker "urllib3>=2.0" "paho-mqtt==1.6.1"
+RUN pip install "grpcio-tools>=1.62.2" "pytest>=7,<8" psutil flask gunicorn flask_cors mpi4py docopt docker "urllib3>=2.0" "paho-mqtt>=2.0,<3"
 
 # Experiments — opencv-python is needed by examples/husky_braitenberg's
 # cam_pf.py (and any other camera-data transceiver function). Without

--- a/src/nrp_event_loop/python/event_loop_engine.py
+++ b/src/nrp_event_loop/python/event_loop_engine.py
@@ -120,8 +120,18 @@ class EventLoopEngine(EventLoopInterface):
             t = msg.topic
             self._topic_callback(t[t.rfind('/')+1:], msg.payload)
 
-        self._client = mqtt.Client(self._mqtt_config["ClientName"] if "ClientName" in self._mqtt_config
-                                   else self._engine_wrapper.get_engine_name(), True)
+        client_name = self._mqtt_config["ClientName"] if "ClientName" in self._mqtt_config \
+            else self._engine_wrapper.get_engine_name()
+
+        # paho-mqtt 2.0 made callback_api_version a required first argument and 2.1+
+        # raises without it. VERSION1 keeps the existing v1 callback signatures
+        # (on_connect(client, userdata, flags, rc), on_message(client, userdata, msg))
+        # working unchanged. Guarded with hasattr so the module still constructs a
+        # client against paho-mqtt 1.x, where CallbackAPIVersion does not exist.
+        client_kwargs = {"client_id": client_name, "clean_session": True}
+        if hasattr(mqtt, "CallbackAPIVersion"):
+            client_kwargs["callback_api_version"] = mqtt.CallbackAPIVersion.VERSION1
+        self._client = mqtt.Client(**client_kwargs)
 
         self._client.on_connect = on_connect
         self._client.on_message = on_message


### PR DESCRIPTION
## What

Closes the paho-mqtt 2.x migration tracked in **EBR2-29**: https://hbpneurorobotics.atlassian.net/browse/EBR2-29

- `src/nrp_event_loop/python/event_loop_engine.py`: construct `mqtt.Client` with an explicit `CallbackAPIVersion.VERSION1` and pass `client_id` as a keyword. paho-mqtt 2.0 made `callback_api_version` the required first positional argument (2.1+ raises without it), so the old `mqtt.Client(name, True)` call broke on any image resolving paho-mqtt >= 2.0. The `hasattr` guard keeps the module constructing a client against paho-mqtt 1.x too.
- `dockerfiles/nrp-core.Dockerfile` + `README.md`: bump the pin `paho-mqtt==1.6.1` -> `paho-mqtt>=2.0,<3`.

## Why VERSION1 (shim) rather than full VERSION2

VERSION1 keeps the existing v1 callback signatures working unchanged:
`on_connect(client, userdata, flags, rc)` and `on_message(client, userdata, msg)`.
A full VERSION2 migration would also have to rewrite `on_connect` to the
`(client, userdata, flags, reason_code, properties)` shape. The ticket explicitly
left the shim-vs-full choice to review -- this PR takes the minimal, low-risk shim.
Note: paho 2.x emits a `Callback API version 1 is deprecated` DeprecationWarning
under VERSION1; a follow-up can move to VERSION2 if we want to silence it.

## Verification

- Code-level: against real `paho-mqtt>=2.0,<3` in a clean venv, the exact
  constructor call and v1 callback assignment succeed.
- Python module parses (`ast.parse`).
- **Not run here:** the full in-container gate (`ctest -R event_loop_engine`
  under a nest-gazebo image rebuilt with paho-mqtt 2.x) -- the image rebuild is
  multi-hour and the local build host was busy. The `pull_request` Actions
  build-validates the image; please run the ctest gate before merge per
  nrp-core/CLAUDE.md.

## Acceptance (EBR2-29)
- [x] `paho-mqtt` pinned `>=2.0,<3` in the installer path (Dockerfile) and README
- [x] `event_loop_engine.py` constructs `mqtt.Client` with an explicit `CallbackAPIVersion`
- [ ] `ctest -R event_loop_engine` green (run in-container before merge)